### PR TITLE
Added GatewayIndividual::completePurchase()

### DIFF
--- a/src/GatewayIndividual.php
+++ b/src/GatewayIndividual.php
@@ -194,12 +194,18 @@ class GatewayIndividual extends AbstractGateway
 	{
 		return $this->getParameter('cancelUrl');
 	}		
+
+    /**
+     * @deprecated Use completePurchase() instead
+     */
 	public function authorize(array $parameters = array())
+    {
+        return $this->completePurchase($parameters);
+    }
+	public function completePurchase(array $parameters = array())
     {
         return $this->createRequest('\yandexmoney\YandexMoney\Message\IndividualAuthorizeRequest', $parameters);
     }
-
-	 
     public function purchase(array $parameters = array())
     {
         return $this->createRequest('\yandexmoney\YandexMoney\Message\IndividualPurchaseRequest', $parameters);


### PR DESCRIPTION
В соответствии с [документаций Omnipay](http://omnipay.thephpleague.com/api/charging/), метод `purchase` должен комплектоваться методом `completePurchase` для подтверждения выполнения оплаты.

В свою очередь метод `authorize()` [должен](http://omnipay.thephpleague.com/api/authorizing/) порождать запрос авторизации суммы на счету клиента.

По-хорошему нужно переименовать IndividualAuthorizeRequest в IndividualCompletePurchaseRequest и дропнуть метод `authorize()`, но для сохранения обратной совместимости предлагаю пока оставить так. 